### PR TITLE
Updated dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-torch = "==0.4.1"
+torch = ">=0.4.1"
 
 [dev-packages]
 tqdm = "==4.23.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,7 +27,7 @@
                 "sha256:e740fb4442ab0cf6a5e5c5279b6ad3cebdeb8f30ce1dabb293cf437178f12a78"
             ],
             "index": "pypi",
-            "version": "==0.4.1"
+            "version": ">=0.4.1"
         }
     },
     "develop": {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(fname):
 
 BASE_URL = "https://github.com/anassinator/bnn"
 INSTALL_REQUIRES = [
-    "torch==0.4.1",
+    "torch>=0.4.1",
 ]
 
 # Parse version information.


### PR DESCRIPTION
Setup.py has `torch==0.4.1` in it. However, it still works fine with 1.1. 
Sven 